### PR TITLE
feat: Introduce Flyway for database migration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ docker-compose.override.yml
 *.sqlite
 postgres_data/
 mysql_data/
+
+#[예외] Flyway 마이그레이션 파일은 포함해야 함 (버전 관리 필요)
+!backend/src/main/resources/db/migration/*.sql

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.3'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -26,6 +26,14 @@ spring:
         default_batch_fetch_size: 100
         jdbc:
           time_zone: Asia/Seoul
+
+  # Flyway 설정
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 0
+    locations: classpath:db/migration
+    validate-on-migrate: true
 
 
   # [NEW] Spring AI 설정 (들여쓰기 중요!)

--- a/backend/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,36 @@
+-- Inner Orbit System - Initial Schema
+-- Created: 2025-12-16
+-- Description: Base schema with LogEntry table including Travel Mode fields
+
+-- Create log_entry table
+CREATE TABLE log_entry (
+    id BIGSERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    stability INTEGER NOT NULL,
+    gravity INTEGER NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    analysis_result JSONB,
+    user_id BIGINT,
+    location VARCHAR(500),
+    sensory_visual TEXT,
+    sensory_auditory TEXT,
+    sensory_tactile TEXT,
+    is_deep_log BOOLEAN NOT NULL DEFAULT false
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_created_at ON log_entry(created_at);
+CREATE INDEX idx_user_id ON log_entry(user_id);
+
+-- Add comments for documentation
+COMMENT ON TABLE log_entry IS 'User emotional logs with Gravity/Stability metrics';
+COMMENT ON COLUMN log_entry.content IS 'User journal entry text';
+COMMENT ON COLUMN log_entry.stability IS 'Inner stability score (0-100)';
+COMMENT ON COLUMN log_entry.gravity IS 'External pressure score (0-100)';
+COMMENT ON COLUMN log_entry.analysis_result IS 'AI cognitive distortion analysis results (JSON)';
+COMMENT ON COLUMN log_entry.location IS 'Travel Mode: Location or place';
+COMMENT ON COLUMN log_entry.sensory_visual IS 'Travel Mode: Visual sensory details';
+COMMENT ON COLUMN log_entry.sensory_auditory IS 'Travel Mode: Auditory sensory details';
+COMMENT ON COLUMN log_entry.sensory_tactile IS 'Travel Mode: Tactile sensory details';
+COMMENT ON COLUMN log_entry.is_deep_log IS 'Flag indicating Travel Mode entry';

--- a/backend/src/test/java/com/greenkey20/innerorbit/InnerOrbitApplicationTests.java
+++ b/backend/src/test/java/com/greenkey20/innerorbit/InnerOrbitApplicationTests.java
@@ -2,8 +2,10 @@ package com.greenkey20.innerorbit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class InnerOrbitApplicationTests {
 
 	@Test

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -1,38 +1,29 @@
-spring:
-  application:
-    name: inner-orbit-test
+# Test environment configuration
+# Overrides main application.yaml for integration tests
 
-  # H2 인메모리 데이터베이스 설정 (테스트용)
+spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
     username: sa
     password:
-    driver-class-name: org.h2.Driver
 
-  # JPA 설정 (테스트용)
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create-drop  # H2 tests use auto-schema generation
     show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
 
-  # H2 Console 설정 (테스트 시 유용)
-  h2:
-    console:
-      enabled: true
+  flyway:
+    enabled: false  # Disable Flyway for H2 tests
 
-  # Spring AI 설정 (테스트에서는 Mock 사용)
   ai:
     openai:
-      api-key: test-api-key
+      api-key: test-key
+      chat:
+        options:
+          model: gpt-4o-mini
 
-# 로깅 설정 (테스트용)
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
     com.greenkey20.innerorbit: DEBUG


### PR DESCRIPTION
## Summary

Introduces Flyway for database migration management, replacing Hibernate's `ddl-auto: update` approach.

## Changes

### Dependencies
- Added `org.flywaydb:flyway-core`
- Added `org.flywaydb:flyway-database-postgresql`

### Database Migration
- Created `V1__initial_schema.sql` with complete LogEntry schema:
  - Core fields (id, content, stability, gravity, timestamps, user_id)
  - AI analysis field (analysis_result JSONB)
  - Travel Mode fields (location, sensory_*, is_deep_log)
  - Indexes (idx_created_at, idx_user_id)
  - Comprehensive column comments

### Configuration
- **application.yaml**: Changed `ddl-auto: update` → `validate`
- **application.yaml**: Added Flyway configuration with `baseline-on-migrate: true`
- **application-test.yaml**: Created test profile to disable Flyway for H2 tests

### Testing
- Updated test classes with `@ActiveProfiles("test")` annotation
- Tests pass successfully with H2 using `ddl-auto: create-drop`

### Version Control
- Updated `.gitignore` to include Flyway migration files
- Exception added: `!backend/src/main/resources/db/migration/*.sql`

## Benefits

✅ **Version Control**: All schema changes tracked in Git
✅ **Team Collaboration**: Migration history shared across team
✅ **Rollback Support**: Can revert schema changes if needed
✅ **Production Ready**: `ddl-auto: validate` prevents accidental schema changes
✅ **Migration History**: `flyway_schema_history` table tracks all applied migrations

## Migration Verification

Successfully tested on local PostgreSQL:
```
Migrating schema "public" to version "1 - initial schema"
Successfully applied 1 migration to schema "public", now at version v1
```

## Next Steps

Future schema changes will use versioned migrations:
```sql
-- V2__add_generated_prompts_table.sql
CREATE TABLE generated_prompts (...);
```

## Related

- Resolves #36
- Prerequisite for #34 (recent question tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)