### PR TITLE
feat: Insight Log trigger를 content로 통합 (Navigation Query 지원)

### DIFF
--- a/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/request/LogEntryCreateRequest.java
+++ b/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/request/LogEntryCreateRequest.java
@@ -14,6 +14,7 @@ import lombok.*;
 @Builder
 public class LogEntryCreateRequest {
 
+    @NotBlank(message = "내용은 필수입니다")
     @Size(max = 10000, message = "내용은 10000자를 초과할 수 없습니다")
     private String content;
 
@@ -61,9 +62,6 @@ public class LogEntryCreateRequest {
     public Boolean getIsDeepLog() {
         return logType == LogType.SENSORY;
     }
-
-    @Size(max = 10000, message = "통찰 트리거는 10000자를 초과할 수 없습니다")
-    private String insightTrigger;
 
     @Size(max = 10000, message = "통찰 추상화는 10000자를 초과할 수 없습니다")
     private String insightAbstraction;

--- a/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/request/LogEntryUpdateRequest.java
+++ b/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/request/LogEntryUpdateRequest.java
@@ -14,8 +14,7 @@ import lombok.*;
 @Builder
 public class LogEntryUpdateRequest {
 
-    // Content is optional for INSIGHT logs (required for DAILY/SENSORY)
-    // Validation happens in service layer based on logType
+    @NotBlank(message = "내용은 필수입니다")
     @Size(max = 10000, message = "내용은 10000자를 초과할 수 없습니다")
     private String content;
 
@@ -62,9 +61,6 @@ public class LogEntryUpdateRequest {
     public Boolean getIsDeepLog() {
         return logType != null && logType == LogType.SENSORY;
     }
-
-    @Size(max = 10000, message = "통찰 트리거는 10000자를 초과할 수 없습니다")
-    private String insightTrigger;
 
     @Size(max = 10000, message = "통찰 추상화는 10000자를 초과할 수 없습니다")
     private String insightAbstraction;

--- a/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/response/LogEntryResponse.java
+++ b/backend/src/main/java/com/greenkey20/innerorbit/domain/dto/response/LogEntryResponse.java
@@ -36,7 +36,6 @@ public class LogEntryResponse {
     private String sensoryAuditory;
     private String sensoryTactile;
     private LogType logType;
-    private String insightTrigger;
     private String insightAbstraction;
     private String insightApplication;
     private String aiFeedback;
@@ -67,7 +66,6 @@ public class LogEntryResponse {
                 .sensoryAuditory(entity.getSensoryAuditory())
                 .sensoryTactile(entity.getSensoryTactile())
                 .logType(entity.getLogType())
-                .insightTrigger(entity.getInsightTrigger())
                 .insightAbstraction(entity.getInsightAbstraction())
                 .insightApplication(entity.getInsightApplication())
                 .aiFeedback(entity.getAiFeedback())

--- a/backend/src/main/java/com/greenkey20/innerorbit/domain/entity/LogEntry.java
+++ b/backend/src/main/java/com/greenkey20/innerorbit/domain/entity/LogEntry.java
@@ -67,9 +67,6 @@ public class LogEntry {
     @Builder.Default
     private LogType logType = LogType.DAILY;
 
-    @Column(name = "insight_trigger", columnDefinition = "TEXT")
-    private String insightTrigger;
-
     @Column(name = "insight_abstraction", columnDefinition = "TEXT")
     private String insightAbstraction;
 

--- a/backend/src/main/resources/db/migration/V6__migrate_insight_trigger_to_content.sql
+++ b/backend/src/main/resources/db/migration/V6__migrate_insight_trigger_to_content.sql
@@ -1,0 +1,19 @@
+-- V6: Migrate Insight Log trigger to content field
+-- Created: 2026-01-01
+-- Description: Unify Insight mode with Daily/Sensory by using content field for observations
+--              This allows Navigation Query to be applied to Insight logs consistently
+
+-- Step 1: Migrate existing insight_trigger data to content field
+-- Only update INSIGHT logs where insight_trigger has data
+UPDATE log_entry
+SET content = insight_trigger
+WHERE log_type = 'INSIGHT'
+  AND insight_trigger IS NOT NULL
+  AND insight_trigger != '';
+
+-- Step 2: Drop the insight_trigger column
+ALTER TABLE log_entry
+DROP COLUMN insight_trigger;
+
+-- Add comment to document the change
+COMMENT ON COLUMN log_entry.content IS 'Main log content. For DAILY: Captain''s Log, SENSORY: Travel notes, INSIGHT: Daily observations';

--- a/frontend/src/components/LogEditor.jsx
+++ b/frontend/src/components/LogEditor.jsx
@@ -51,8 +51,8 @@ export default function LogEditor({
     };
 
     const handleAiKeywordSuggestion = async () => {
-        // Validation: Trigger 필드 확인
-        if (!deepLogData.insightTrigger || deepLogData.insightTrigger.trim().length < 10) {
+        // Validation: Content 필드 확인
+        if (!message || message.trim().length < 10) {
             alert('관찰 내용을 10자 이상 입력해주세요. AI가 더 정확한 키워드를 추천할 수 있습니다.');
             return;
         }
@@ -63,7 +63,7 @@ export default function LogEditor({
             const response = await fetch('/api/ai/insights/suggest-keywords', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ trigger: deepLogData.insightTrigger })
+                body: JSON.stringify({ trigger: message })
             });
 
             if (!response.ok) {
@@ -108,7 +108,7 @@ export default function LogEditor({
     const isSubmitDisabled = logMode === 'SENSORY'
         ? !message.trim() && !deepLogData.location && !deepLogData.sensoryVisual && !deepLogData.sensoryAuditory && !deepLogData.sensoryTactile
         : logMode === 'INSIGHT'
-        ? !deepLogData.insightTrigger?.trim() || !deepLogData.insightAbstraction?.trim() || !deepLogData.insightApplication?.trim()
+        ? !message.trim() || !deepLogData.insightAbstraction?.trim() || !deepLogData.insightApplication?.trim()
         : !message.trim();
     return (
         <>
@@ -243,14 +243,14 @@ export default function LogEditor({
                 ) : logMode === 'INSIGHT' ? (
                     /* Insight Mode - CS Concept Mapping Form */
                     <div className="space-y-4">
-                        {/* Trigger Input */}
+                        {/* Observation (Content) Input */}
                         <div className="relative group">
                             <label className="text-xs font-semibold text-violet-600 mb-1.5 block">
-                                1️⃣ Trigger (관찰)
+                                1️⃣ Observation (관찰)
                             </label>
                             <textarea
-                                value={deepLogData.insightTrigger || ''}
-                                onChange={(e) => handleFieldChange('insightTrigger', e.target.value)}
+                                value={message}
+                                onChange={(e) => onMessageChange(e.target.value)}
                                 placeholder="일상에서 관찰한 것을 적어보세요... (예: 친구가 동시에 여러 채팅에 답장하다 놓친 메시지가 있었다)"
                                 className="w-full h-24 p-4 bg-white border border-violet-200 rounded-xl resize-none focus:ring-2 focus:ring-violet-300 focus:border-violet-400 text-slate-700 leading-relaxed placeholder:text-violet-300 text-sm transition-all shadow-sm font-sans"
                             />

--- a/frontend/src/components/LogHistory.jsx
+++ b/frontend/src/components/LogHistory.jsx
@@ -49,7 +49,6 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
     const [editSensoryTactile, setEditSensoryTactile] = useState('');
 
     // Insight Log 필드 상태
-    const [editInsightTrigger, setEditInsightTrigger] = useState('');
     const [editInsightAbstraction, setEditInsightAbstraction] = useState('');
     const [editInsightApplication, setEditInsightApplication] = useState('');
 
@@ -115,7 +114,6 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
 
         // Insight Log 필드 로드
         if (entry.logType === 'INSIGHT') {
-            setEditInsightTrigger(entry.insightTrigger || '');
             setEditInsightAbstraction(entry.insightAbstraction || '');
             setEditInsightApplication(entry.insightApplication || '');
         }
@@ -139,7 +137,6 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
         // Insight Log 엔트리인 경우 통찰 필드도 함께 전달
         else if (entry && entry.logType === 'INSIGHT') {
             logFields = {
-                insightTrigger: editInsightTrigger,
                 insightAbstraction: editInsightAbstraction,
                 insightApplication: editInsightApplication,
                 logType: 'INSIGHT'
@@ -501,23 +498,10 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
                                     {isEditing ? (
                                         /* Edit Mode - Input Fields */
                                         <>
-                                            {/* Trigger Input */}
-                                            <div className="mb-3">
-                                                <label className="flex items-center gap-2 text-xs font-bold text-slate-700 mb-2">
-                                                    1️⃣ Trigger (관찰)
-                                                </label>
-                                                <textarea
-                                                    value={editInsightTrigger}
-                                                    onChange={(e) => setEditInsightTrigger(e.target.value)}
-                                                    placeholder="일상에서 관찰한 것을 적어보세요..."
-                                                    className="w-full h-20 px-3 py-2 bg-white border border-violet-300 rounded-lg resize-none focus:ring-2 focus:ring-violet-400 focus:border-violet-400 text-sm text-slate-700 placeholder:text-violet-300"
-                                                />
-                                            </div>
-
                                             {/* Abstraction Input */}
                                             <div className="mb-3">
                                                 <label className="flex items-center gap-2 text-xs font-bold text-slate-700 mb-2">
-                                                    2️⃣ Abstraction (CS 개념 연결)
+                                                    1️⃣ Abstraction (CS 개념 연결)
                                                 </label>
                                                 <textarea
                                                     value={editInsightAbstraction}
@@ -530,7 +514,7 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
                                             {/* Application Input */}
                                             <div className="mb-3">
                                                 <label className="flex items-center gap-2 text-xs font-bold text-slate-700 mb-2">
-                                                    3️⃣ Application (실무 적용)
+                                                    2️⃣ Application (실무 적용)
                                                 </label>
                                                 <textarea
                                                     value={editInsightApplication}
@@ -543,14 +527,14 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
                                     ) : (
                                         /* View Mode - Display Data */
                                         <>
-                                            {/* Trigger */}
-                                            {entry.insightTrigger && (
+                                            {/* Observation */}
+                                            {entry.content && (
                                                 <div className="mb-3">
                                                     <div className="flex items-center gap-2 mb-1.5">
                                                         <Lightbulb className="w-4 h-4 text-violet-600" />
-                                                        <span className="text-xs font-bold text-violet-700">1️⃣ Trigger (관찰)</span>
+                                                        <span className="text-xs font-bold text-violet-700">1️⃣ Observation (관찰)</span>
                                                     </div>
-                                                    <p className="text-sm text-slate-700 pl-6 leading-relaxed">{entry.insightTrigger}</p>
+                                                    <p className="text-sm text-slate-700 pl-6 leading-relaxed">{entry.content}</p>
                                                 </div>
                                             )}
 
@@ -559,7 +543,7 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
                                                 <div className="mb-3">
                                                     <div className="flex items-center gap-2 mb-1.5">
                                                         <Sparkles className="w-4 h-4 text-purple-600" />
-                                                        <span className="text-xs font-bold text-purple-700">2️⃣ Abstraction (CS 개념)</span>
+                                                        <span className="text-xs font-bold text-purple-700">1️⃣ Abstraction (CS 개념)</span>
                                                     </div>
                                                     <p className="text-sm text-slate-700 pl-6 leading-relaxed">{entry.insightAbstraction}</p>
                                                 </div>
@@ -570,7 +554,7 @@ export default function LogHistory({ entries, onDeleteEntry, onUpdateEntry, onUp
                                                 <div className="mb-3">
                                                     <div className="flex items-center gap-2 mb-1.5">
                                                         <Hexagon className="w-4 h-4 text-violet-600" />
-                                                        <span className="text-xs font-bold text-violet-700">3️⃣ Application (실무 적용)</span>
+                                                        <span className="text-xs font-bold text-violet-700">2️⃣ Application (실무 적용)</span>
                                                     </div>
                                                     <p className="text-sm text-slate-700 pl-6 leading-relaxed">{entry.insightApplication}</p>
                                                 </div>


### PR DESCRIPTION
## Summary
Insight 모드의 trigger 필드를 content로 통합하여 Daily/Sensory 모드와 일관된 구조로 변경했습니다. 이제 Insight 모드에서도 Navigation Query의 "Apply to Log" 기능을 사용할 수 있습니다.

## Changes

### Backend
- **V6 Migration**: `insight_trigger` 데이터를 `content`로 이동 후 컬럼 DROP
- **LogEntry Entity**: `insightTrigger` 필드 제거
- **DTOs**: `insightTrigger` 제거, `content`를 모든 `logType`에서 필수로 변경
- **LogService**: Insight 모드에서도 `content` 필수 검증, `generateInsightFeedback`에서 `content` 사용

### Frontend
- **LogEditor.jsx**: 
  - Insight 모드에서 Trigger input → Observation (content) input으로 변경
  - Navigation Query "Apply to Log" 버튼이 Insight content에도 적용 가능
  - AI Suggest 키워드 추천이 content 기반으로 작동
- **LogHistory.jsx**: 
  - `insightTrigger` → `content` 표시/수정 로직 변경
  - Architecture of Insight 구조 유지: **Observation (content) + Abstraction + Application**

## Benefits
✅ **일관성 있는 UX**: Daily/Sensory/Insight 모두 동일한 content 필드 사용  
✅ **Navigation Query 통합**: Insight에서도 Navigation Query 활용 가능  
✅ **Inner Orbit 컨셉 강화**: Flight Telemetry 관찰 + Navigation Query 가이드  
✅ **코드 단순화**: 예외 처리 제거, Entity/DTO/Service 레이어 통일  

## Migration
- 기존 Insight Log 데이터는 V6 Migration에서 자동으로 `insight_trigger` → `content`로 이동
- `insight_trigger` 컬럼은 완전히 제거됨

## Test Plan
- [x] 백엔드 빌드 성공
- [x] 프론트엔드 빌드 성공
- [x] V6 Migration 로컬 테스트 성공
- [ ] Insight Log 입력 테스트 (Navigation Query 적용 포함)
- [ ] 기존 Insight Log 조회 테스트
- [ ] AI Feedback 요청 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)